### PR TITLE
Workaround limit api too high in tvm

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -145,12 +145,12 @@ def config_cython():
     try:
         from Cython.Build import cythonize
 
-        # for python 3.12+, use limited API for future compact
+        # for python 3.8+, use limited API for future compact
         limited_api_kwargs = {}
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 8):
             limited_api_kwargs = {
                 "define_macros": [
-                    ("Py_LIMITED_API", 0x030C0000),
+                    ("Py_LIMITED_API", 0x03080000),
                 ],
                 "py_limited_api": True,
             }


### PR DESCRIPTION
Needed-by: https://github.com/tile-ai/tilelang/pull/939

Currently, tvm will build limited api cython library for 3.12+, even if we're targeting 3.8+ in tilelang. This workaround just relax the version.

This issue should be solved by future tvm-ffi integration.

This part is no longer in upstream tvm so I submitted here.