### PR TITLE
[Fix][Debug] Fix source code mapping in submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -793,7 +793,8 @@ endif()
 
 # Change relative paths in backtrace to absolute ones
 if(TVM_IS_DEBUG_BUILD)
-  set(FILE_PREFIX_MAP_FLAG "-ffile-prefix-map=..=${CMAKE_CURRENT_SOURCE_DIR}")
+  # Do not set prefix map when tvm is built as submodule
+  # set(FILE_PREFIX_MAP_FLAG "-ffile-prefix-map=..=${CMAKE_CURRENT_SOURCE_DIR}")
   target_compile_options(tvm PRIVATE "${FILE_PREFIX_MAP_FLAG}")
   CHECK_CXX_COMPILER_FLAG("${FILE_PREFIX_MAP_FLAG}" FILE_PREFIX_MAP_SUPPORTED)
   if(FILE_PREFIX_MAP_SUPPORTED)


### PR DESCRIPTION
The original setting tries to set absolute path when building a debug tvm, so that debugger will be able to locate source file. However this seems wrong when building tvm as a submodule: lldb will look for wrong file.

```
CompileUnit: id = {0x00000000}, file = "/Users/yyc/repo/tilelang/3rdparty/tvm/3rdparty/tvm/src/runtime/metal/metal_module.mm", language = "objective-c++"
```

With this PR, the source file could be founded without manually mapping.

I also tried `set(FILE_PREFIX_MAP_FLAG "-ffile-prefix-map=../../..=${CMAKE_CURRENT_SOURCE_DIR}")` but it doesn't work.

This chang is very limited to tilelang and ad-hoc, and does not suite for upstream tvm. Also open for some better fix cc @Hzfengsy 

Also this seems a lldb-specific issue.