### PR TITLE
Fix TVMDerivedObject slots for apache-tvm-ffi compatibility

### DIFF
--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -108,6 +108,7 @@ def derived_object(cls: type) -> type:
     class TVMDerivedObject(metadata["cls"]):  # type: ignore
         """The derived object to avoid cyclic dependency."""
 
+        __slots__ = ("_inst", "__weakref__")
         _cls = cls
         _type = "TVMDerivedObject"
 

--- a/python/tvm/runtime/support.py
+++ b/python/tvm/runtime/support.py
@@ -151,6 +151,7 @@ def derived_object(cls: Type[T]) -> Type[T]:
     class TVMDerivedObject(metadata["cls"]):  # type: ignore
         """The derived object to avoid cyclic dependency."""
 
+        __slots__ = ("_inst", "__weakref__")
         _cls = cls
         _type = "TVMDerivedObject"
 


### PR DESCRIPTION
## Summary

The `derived_object` decorator creates a `TVMDerivedObject` class that inherits from `CObject` (via `apache-tvm-ffi`). `CObject` is a C extension type with `__slots__ = ()` and **no instance `__dict__`**, so when `__init__` tries to set `self._inst`, it fails with:

```
AttributeError: '_NestedLoopCheckVisitor' object has no attribute '_inst'
```

This breaks any code path using derived TVM objects, including importing the Mamba3 MIMO kernel (`mamba_ssm.ops.tilelang.mamba3.mamba3_mimo`).

## Root cause

tilelang migrated from a custom TVM fork to `apache-tvm-ffi` (October 2025). The old fork's `Object` type allowed arbitrary instance attributes via `__dict__`; the new `CObject` does not — it uses `__slots__` throughout the hierarchy.

## Fix

Add `__slots__ = ("_inst", "__weakref__")` to the dynamically created `TVMDerivedObject` class in **both copies** of the decorator:

- **`python/tvm/runtime/support.py`** — used by `tir/functor.py` and `relax/expr_functor.py`
- **`python/tvm/meta_schedule/utils.py`** — used by most `@derived_object` consumers (LocalRunner, LocalBuilder, cost models, etc.)

Why these two slots:
- **`_inst`** — needed for instance storage (set in `__init__`)
- **`__weakref__`** — needed because the code creates `weakref.ref(self)` for cyclic dependency avoidance

This is a backwards-compatible change. Classes that previously worked with `__dict__` will continue to work with explicit slots.

## How to verify

```python
python -c "from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo import mamba3_mimo; print('MIMO import OK')"
```

Should succeed without the `_NestedLoopCheckVisitor` `AttributeError`.