### PR TITLE
Fix duplicate __weakref__ declaration in derived_object wrappers

### DIFF
--- a/python/tvm/meta_schedule/utils.py
+++ b/python/tvm/meta_schedule/utils.py
@@ -104,11 +104,17 @@ def derived_object(cls: type) -> type:
     metadata = getattr(base, "_tvm_metadata")
     fields = metadata.get("fields", [])
     methods = metadata.get("methods", [])
+    base_cls = metadata["cls"]
+    derived_slots = (
+        ("_inst",)
+        if hasattr(base_cls, "__weakref__") or getattr(base_cls, "__weakrefoffset__", 0)
+        else ("_inst", "__weakref__")
+    )
 
-    class TVMDerivedObject(metadata["cls"]):  # type: ignore
+    class TVMDerivedObject(base_cls):  # type: ignore
         """The derived object to avoid cyclic dependency."""
 
-        __slots__ = ("_inst", "__weakref__")
+        __slots__ = derived_slots
         _cls = cls
         _type = "TVMDerivedObject"
 

--- a/python/tvm/runtime/support.py
+++ b/python/tvm/runtime/support.py
@@ -147,11 +147,17 @@ def derived_object(cls: Type[T]) -> Type[T]:
     metadata = getattr(base, "_tvm_metadata")
     fields = metadata.get("fields", [])
     methods = metadata.get("methods", [])
+    base_cls = metadata["cls"]
+    derived_slots = (
+        ("_inst",)
+        if hasattr(base_cls, "__weakref__") or getattr(base_cls, "__weakrefoffset__", 0)
+        else ("_inst", "__weakref__")
+    )
 
-    class TVMDerivedObject(metadata["cls"]):  # type: ignore
+    class TVMDerivedObject(base_cls):  # type: ignore
         """The derived object to avoid cyclic dependency."""
 
-        __slots__ = ("_inst", "__weakref__")
+        __slots__ = derived_slots
         _cls = cls
         _type = "TVMDerivedObject"
 


### PR DESCRIPTION
### Summary

#32 added `__slots__ = ("_inst", "__weakref__")` to the dynamically generated `TVMDerivedObject` in both `python/tvm/runtime/support.py` and `python/tvm/meta_schedule/utils.py`.

That assumption is not always valid. In environments where `metadata["cls"]` already provides weakref support, redefining `__weakref__` on the wrapper raises:

`TypeError: __weakref__ slot disallowed: we already got one`

This change preserves the intent of the previous fix while avoiding the regression:
- `_inst` is always kept in `__slots__`
- `__weakref__` is only added when the base class does not already provide weakref support