### PR TITLE
[Metal] Fix kernel dispatch for MetalRawStream (torch interop)

### DIFF
--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -242,9 +242,13 @@ class MetalWrappedFunc {
       int blockSize = wl.block_dim(0) * wl.block_dim(1) * wl.block_dim(2);
       auto maxTotalThreadsPerThreadgroup = scache_[device_id].maxTotalThreadsPerThreadgroup;
       TVM_FFI_ICHECK_LE(blockSize, maxTotalThreadsPerThreadgroup);
-      // Reuse the pending compute encoder to batch dispatches.
-      // The encoder is flushed on sync, copy, or buffer deallocation.
-      id<MTLComputeCommandEncoder> encoder = stream->GetPendingComputeEncoder(func_name_);
+      // [tilelang] Use standalone encoder instead of GetPendingComputeEncoder().
+      // MetalRawStream wraps torch's command buffer with a nil queue, so the
+      // batched dispatch path (GetOrCreatePendingCommandBuffer) produces nil
+      // encoder. We create a fresh encoder per dispatch and endEncoding
+      // immediately — torch owns the command buffer and handles commit/sync.
+      id<MTLCommandBuffer> cb = stream->GetCommandBuffer();
+      id<MTLComputeCommandEncoder> encoder = [cb computeCommandEncoder];
       [encoder setComputePipelineState:scache_[device_id]];
       for (size_t i = 0; i < num_buffer_args_; ++i) {
         void* buf = args[static_cast<int>(i)].cast<void*>();
@@ -259,8 +263,10 @@ class MetalWrappedFunc {
       MTLSize dimGrid = MTLSizeMake(wl.grid_dim(0), wl.grid_dim(1), wl.grid_dim(2));
       MTLSize dimBlock = MTLSizeMake(wl.block_dim(0), wl.block_dim(1), wl.block_dim(2));
       [encoder dispatchThreadgroups:dimGrid threadsPerThreadgroup:dimBlock];
-      // Dispatches are batched via the pending compute encoder; no explicit
-      // endEncoding or commit here — those happen on FlushCommandBuffer().
+      // [tilelang] endEncoding immediately since torch owns the command buffer.
+      // Upstream batched path defers this to FlushCommandBuffer(), but
+      // MetalRawStream does not support batching (nil queue).
+      [encoder endEncoding];
     };
   }
 


### PR DESCRIPTION
## Summary

Fix Metal kernel dispatch producing all-zero results after the v0.25.dev0 merge.

## Problem

The v0.25.dev0 merge refactored Metal runtime to use batched dispatch via `GetPendingComputeEncoder()`. However, `MetalRawStream` (used for torch MPS interop) passes `nullptr` as the device, resulting in a nil command queue. The batched path calls `GetOrCreatePendingCommandBuffer()` which uses the nil queue — producing nil command buffer and nil encoder. All `[encoder dispatch...]` calls become Objective-C message-sends to nil (no-ops), so kernel output stays zero.

## Fix

Restore the pre-merge dispatch pattern for the torch interop path:
- Use `stream->GetCommandBuffer()` to get the torch-owned command buffer directly
- Create a standalone compute encoder on it
- Dispatch the kernel
- Immediately `[encoder endEncoding]`

This matches the original design where torch manages the command buffer lifecycle (commit/sync), and we only need to end the encoder before returning control.

Also fixes an off-by-one bug in `SetMetalStream`'s vector resize (`device_id` → `device_id + 1`).

## Testing

All Metal tests pass after this fix:
```
testing/python/metal/test_metal_codegen.py::test_gemm_float32 PASSED
testing/python/metal/test_metal_codegen.py::test_gemm_float16 PASSED
testing/python/metal/test_metal_codegen.py::test_gemm_int32 PASSED
testing/python/metal/test_metal_codegen_linux.py::test_metal_codegen_float32 PASSED
testing/python/metal/test_metal_codegen_linux.py::test_metal_codegen_float16 PASSED
testing/python/metal/test_metal_codegen_linux.py::test_metal_codegen_int32 PASSED
```