### PR TITLE
Gate libtvm compatibility symlinks to Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,10 +562,12 @@ set_target_properties(tvm PROPERTIES
 )
 # Create compatibility symlinks so Python can find libtvm_runtime.so and
 # libtvm_compiler.so from the unified libtvm.so.
-add_custom_command(TARGET tvm POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E create_symlink libtvm.so "${CMAKE_BINARY_DIR}/lib/libtvm_runtime.so"
-  COMMAND ${CMAKE_COMMAND} -E create_symlink libtvm.so "${CMAKE_BINARY_DIR}/lib/libtvm_compiler.so"
-)
+if(UNIX)
+  add_custom_command(TARGET tvm POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink libtvm.so "${CMAKE_BINARY_DIR}/lib/libtvm_runtime.so"
+    COMMAND ${CMAKE_COMMAND} -E create_symlink libtvm.so "${CMAKE_BINARY_DIR}/lib/libtvm_compiler.so"
+  )
+endif()
 
 # Place runtime/compiler/allvisible artifacts under build/lib/ to mirror the
 # tvm-ffi layout and make tvm_ffi.libinfo.load_lib_ctypes(package="tvm") able


### PR DESCRIPTION
## Summary

Gate the `libtvm_runtime.so` and `libtvm_compiler.so` compatibility symlinks behind `UNIX`.

These symlinks are useful for Unix-style shared library naming, but the same `POST_BUILD` rule is not valid for the Windows split-DLL build. Windows should produce real DLL artifacts instead of trying to create Unix `.so` symlinks.

## Testing

- Built as part of TileLang Windows split-DLL validation.