### PR TITLE
[TIRX] Exclude StmtNode::span from structural equality/hash

### DIFF
--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -51,7 +51,10 @@ class StmtNode : public ffi::Object {
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<StmtNode>().def_ro("span", &StmtNode::span);
+    // Spans are source debug info and must not participate in structural
+    // equality or hashing (same convention as BufferNode::span).
+    refl::ObjectDef<StmtNode>().def_ro("span", &StmtNode::span,
+                                       refl::AttachFieldFlag::SEqHashIgnore());
   }
 
   TVM_OBJECT_ENABLE_SCRIPT_PRINTER();


### PR DESCRIPTION
`BufferNode::span` and `BaseExprNode::span` already carry `SEqHashIgnore`; `StmtNode::span` was missed because no one injected stmt spans before. Once spans are populated (tilelang parser injection), StructuralEqual/Hash starts producing false mismatches on identical IR. One-line alignment with the existing convention.
