### PR TITLE
[TIRx][Codegen] Preserve vector dtype in tvm_access_ptr lowering

### DIFF
--- a/src/target/intrin_rule.cc
+++ b/src/target/intrin_rule.cc
@@ -23,10 +23,10 @@
  */
 #include "intrin_rule.h"
 
+#include <tvm/runtime/logging.h>
 #include <tvm/tirx/buffer.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/op_attr_types.h>
-#include <tvm/runtime/logging.h>
 
 namespace tvm {
 namespace codegen {
@@ -135,12 +135,9 @@ TVM_REGISTER_OP("tirx.tvm_access_ptr")
       Var buffer_var = Downcast<Var>(call->args[1]);
       PrimExpr offset = call->args[2];
       TVM_FFI_ICHECK(call->dtype.is_handle());
-      if (dtype.lanes() != 1) {
-        offset = offset * make_const(offset.dtype(), dtype.lanes());
-        offset = Ramp(offset, make_const(offset.dtype(), 1), dtype.lanes());
-      }
-      Buffer dummy_buf(buffer_var, dtype.element_of(), {offset + 1}, {}, 0, buffer_var->name_hint,
-                       0, 0, kDefault);
+      // Access-pointer offsets are measured in units of dtype, including its lanes.
+      Buffer dummy_buf(buffer_var, dtype, {offset + 1}, {}, 0, buffer_var->name_hint, 0, 0,
+                       kDefault);
       BufferLoad buf_load(dummy_buf, {offset});
       return Call(DataType::Handle(), builtin::address_of(), {buf_load});
     });

--- a/tests/python/tirx-transform/test_tir_transform_lower_intrin.py
+++ b/tests/python/tirx-transform/test_tir_transform_lower_intrin.py
@@ -94,6 +94,26 @@ def get_ref_data():
     return list(itertools.product(x, y))
 
 
+def test_lower_vector_access_ptr():
+    buffer = tvm.tirx.decl_buffer((8,), "float32x2", name="A")
+    access_ptr = buffer.access_ptr(access_mask=3, offset=2, extent=4)
+
+    assert access_ptr.op.name == "tirx.tvm_access_ptr"
+    assert int(access_ptr.args[2]) == 2
+    assert int(access_ptr.args[3]) == 4
+    assert int(access_ptr.args[4]) == 3
+
+    lowered = lower_intrin([buffer], access_ptr)
+    assert lowered.op.name == "tirx.address_of"
+
+    load = lowered.args[0]
+    assert isinstance(load, tvm.tirx.BufferLoad)
+    assert load.buffer.data.same_as(buffer.data)
+    assert str(load.buffer.dtype) == "float32x2"
+    assert len(load.indices) == 1
+    assert int(load.indices[0]) == 2
+
+
 @tvm.testing.requires_llvm
 def test_lower_floordiv():
     data = get_ref_data()


### PR DESCRIPTION
## Summary

- Preserve the declared vector dtype when lowering `tirx.tvm_access_ptr`.
- Keep pointer offsets in units of the complete dtype, including its lane count, as required by the builtin contract.
- Add a regression test covering a vector dtype, a nonzero offset, extent metadata, and a read-write access mask.

## Problem

`tvm_access_ptr` defines `offset` and `extent` in units of its declared dtype. For example:

```text
tvm_access_ptr(type_annotation("float32x2"), A, 2, 4, 3)
```

denotes a `float32x2*` pointing at vector element 2. The previous lowering instead converted the scalar offset into a vector-valued index:

```text
address_of(BufferLoad(float32_buffer, Ramp(4, 1, 2)))
```

Source codegen could consequently emit pointer arithmetic such as:

```cpp
((float*)workspace) + make_int2(0, 1)
```

This is not valid C/CUDA pointer arithmetic and causes NVCC to report `float* + int2` when a packed TileLang AllReduce passes a vector-typed shared workspace through `tvm_access_ptr`.

With this change, the same intrinsic lowers to a scalar index on a vector-typed buffer:

```text
address_of(BufferLoad(float32x2_buffer, 2))
```

and CUDA codegen emits a typed pointer such as `&(workspace[0])`. The original `tvm_access_ptr` remains available to analysis passes before `LowerIntrin`, including its offset, extent, and read/write mask.

## Changes

- Remove lane multiplication and `Ramp` construction from vector `tvm_access_ptr` lowering.
- Construct the temporary buffer with the complete declared dtype instead of `dtype.element_of()`.
- Verify that lowering preserves the vector dtype and scalar offset while the original intrinsic carries `offset=2`, `extent=4`, and `rw_mask=3`.

## Reproduction

The following program reproduces the failure with a TileLang checkout using this TVM fork on an SM100-or-later CUDA GPU:

```python
import tilelang
import tilelang.language as T
import torch

M = 4
N = 512
THREADS = 128
VEC_SIZE = 8


def fragment_layout(i, j):
    linear = i * N + j
    thread_id = linear // VEC_SIZE % THREADS
    local_id = linear // (THREADS * VEC_SIZE) * VEC_SIZE + linear % VEC_SIZE
    return thread_id, local_id


@tilelang.jit(out_idx=-1)
def make_kernel():
    @T.prim_func
    def main(A: T.Tensor((M, N), T.float32), B: T.Tensor((M,), T.float32)):
        with T.Kernel(1, threads=THREADS):
            src = T.alloc_fragment((M, N), T.float32)
            dst = T.alloc_fragment((M,), T.float32)
            T.annotate_layout({src: T.Fragment(src.shape, forward_fn=fragment_layout)})
            T.copy(A, src)
            T.reduce_sum(src, dst, dim=1, batch=2)
            T.copy(dst, B)

    return main


tilelang.disable_cache()
kernel = make_kernel()
call = next(
    line.strip()
    for line in kernel.get_kernel_source().splitlines()
    if "AllReduce<" in line
)
print(call)

a = torch.randn((M, N), dtype=torch.float32, device="cuda")
actual = kernel(a)
torch.cuda.synchronize()
torch.testing.assert_close(actual, a.sum(dim=1), atol=1e-4, rtol=1e-4)
```

Before this patch, NVCC rejects the generated `float* + int2` expression. After this patch, the program prints a call ending in:

```cpp
::run_batch(&(dst_pack_1[0]), &(workspace[0]));
```

and passes the numerical comparison.

## Validation

- `cmake --build build -j$(nproc)`
- `python -m pytest tests/python/tirx-transform/test_tir_transform_lower_intrin.py -q -k vector_access_ptr`
- `python -m pytest testing/python/cuda/test_cuda_f32x2_intrinsics.py testing/python/issue/test_tilelang_issue_2524.py -q -k reduce` in the TileLang checkout (24 passed)
- Ran the reproduction program above successfully on an SM103 CUDA GPU

## Risk

Scalar access-pointer lowering is unchanged. The vector path now follows the documented dtype-based offset units directly; the regression uses a nonzero offset to guard against accidental byte- or scalar-element reinterpretation.
