### PR TITLE
[FFI] Fix compatibility with tvm-ffi 0.1.12

### DIFF
--- a/python/tvm/ir/attrs.py
+++ b/python/tvm/ir/attrs.py
@@ -79,6 +79,16 @@ class Attrs(Object):
 class DictAttrs(Attrs):
     """Dictionary attributes."""
 
+    @property
+    def __dict__(self):
+        """Return the underlying key-value map as a Python dict.
+
+        Defining this property explicitly prevents tvm_ffi from trying to
+        install the reflected C++ field named ``__dict__``.  Python reserves
+        that class attribute, so installing it via ``setattr`` fails.
+        """
+        return dict(self._dict())
+
     def _dict(self):
         """Get internal dict"""
         return _ffi_api.DictAttrsGetDict(self)

--- a/src/ir/repr.cc
+++ b/src/ir/repr.cc
@@ -24,17 +24,17 @@
  * The legacy ReprPrinter has been replaced by ffi::ReprPrint.  This file:
  *  - Implements the Dump() debug helpers (they call ffi::ReprPrint).
  *  - Registers node.AsRepr (for backward Python compatibility) via ffi::ReprPrint.
- *  - Registers __ffi_repr__ hooks for ffi::reflection::AccessPath and AccessStep.
+ *
+ * Note: __ffi_repr__ hooks for ffi::reflection::AccessPath and AccessStep are
+ * registered by tvm-ffi itself.  Registering them again here causes a
+ * double-registration abort when loading against tvm-ffi 0.1.12 or newer.
  */
 #include <tvm/ffi/cast.h>
 #include <tvm/ffi/extra/dataclass.h>
 #include <tvm/ffi/function.h>
-#include <tvm/ffi/reflection/access_path.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/repr.h>
 #include <tvm/runtime/device_api.h>
-
-#include <sstream>
 
 namespace tvm {
 
@@ -48,51 +48,5 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   // Python's tvm.runtime._ffi_node_api sets __object_repr__ = AsRepr via init_ffi_api.
   refl::GlobalDef().def("node.AsRepr",
                         [](ffi::Any obj) -> ffi::String { return ffi::ReprPrint(obj); });
-  // Register __ffi_repr__ for ffi::reflection::AccessPath/AccessStep so that ffi.ReprPrint
-  // uses the concise "<root>.field[idx]" format.
-  //
-  // AccessStep: format one step fragment (e.g. ".field", "[0]", "[key]?").
-  refl::TypeAttrDef<ffi::reflection::AccessStepObj>().def(
-      refl::type_attr::kRepr,
-      [](ffi::reflection::AccessStep step, ffi::Function fn_repr) -> ffi::String {
-        using ffi::reflection::AccessKind;
-        std::ostringstream os;
-        switch (step->kind) {
-          case AccessKind::kAttr:
-            os << "." << step->key.cast<ffi::String>();
-            break;
-          case AccessKind::kArrayItem:
-            os << "[" << step->key.cast<int64_t>() << "]";
-            break;
-          case AccessKind::kMapItem:
-            os << "[" << fn_repr(step->key).cast<ffi::String>() << "]";
-            break;
-          case AccessKind::kAttrMissing:
-            os << "." << step->key.cast<ffi::String>() << "?";
-            break;
-          case AccessKind::kArrayItemMissing:
-            os << "[" << step->key.cast<int64_t>() << "]?";
-            break;
-          case AccessKind::kMapItemMissing:
-            os << "[" << fn_repr(step->key).cast<ffi::String>() << "]?";
-            break;
-        }
-        return os.str();
-      });
-  // ffi::reflection::AccessPath: recurse through parent via fn_repr rather than walking the
-  // linked list manually.  Root (no step) emits "<root>"; each non-root node
-  // prepends its parent's repr and appends the current step's repr.
-  refl::TypeAttrDef<ffi::reflection::AccessPathObj>().def(
-      refl::type_attr::kRepr,
-      [](ffi::reflection::AccessPath path, ffi::Function fn_repr) -> ffi::String {
-        if (!path->step.has_value()) {
-          // Root node: no parent, no step.
-          return "<root>";
-        }
-        std::ostringstream os;
-        os << fn_repr(path->parent.value()).cast<ffi::String>();
-        os << fn_repr(path->step.value()).cast<ffi::String>();
-        return os.str();
-      });
 }
 }  // namespace tvm

--- a/tests/python/ir/test_ir_attrs.py
+++ b/tests/python/ir/test_ir_attrs.py
@@ -29,6 +29,7 @@ def test_dict_attrs():
     assert len(dattr) == 4
     assert len([x for x in dattr.keys()]) == 4
     assert len(dattr.items()) == 4
+    assert dattr.__dict__ == {"x": 1, "y": 10, "name": "xyz", "padding": [0, 0]}
 
 
 def test_attrs_equal():


### PR DESCRIPTION
## Summary

- stop registering the AccessPath and AccessStep __ffi_repr__ hooks already provided by tvm-ffi 0.1.12, avoiding a duplicate-registration abort at library load
- define DictAttrs.__dict__ explicitly so tvm-ffi does not try to install the reserved Python class attribute
- add regression coverage for the DictAttrs dictionary view

## Testing

- built the tvm target successfully (565/565 steps)
- verified import, AccessPath repr, and DictAttrs behavior while loading apache-tvm-ffi==0.1.12
- python -m pytest -q -p no:tvm.testing.plugin tests/python/ir/test_ir_attrs.py tests/python/ir/test_container_structural_equal.py (21 passed)
- ruff check python/tvm/ir/attrs.py tests/python/ir/test_ir_attrs.py
- clang-format --dry-run --Werror src/ir/repr.cc
- git diff --check