### PR TITLE
[Z3] Distinguish unknown value counts from unsat

### DIFF
--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -725,7 +725,8 @@ class Z3Prover {
    *                        consecutive integers. E.g., with min_consecutive=4:
    *                        {0,1,2,3,16,17,18,19} is valid, {0,1,4,5} is invalid.
    * \return The number of distinct values that satisfy the constraints,
-   *         -1 if the problem is unsatisfiable or an error occurred,
+   *         0 if the problem is unsatisfiable,
+   *         -1 if Z3 returns unknown or an error occurred,
    *         -2 if the min_consecutive constraint is not satisfied.
    */
   TVM_DLL int64_t CountSatisfyingValues(const Var& var, int64_t max_count = 2048, int64_t min_consecutive = 1);

--- a/src/target/z3/z3_prover_on.cc
+++ b/src/target/z3/z3_prover_on.cc
@@ -440,7 +440,8 @@ public:
    * \param var The variable to count values for
    * \param max_count Safety limit on enumeration
    * \param min_consecutive Minimum consecutive count requirement (0 to disable)
-   * \return Number of satisfying values, -1 on error, -2 if min_consecutive constraint not met
+   * \return Number of satisfying values, -1 if Z3 returns unknown or an error
+   * occurs, -2 if min_consecutive constraint not met
    */
   int64_t CountSatisfyingValues(const Var& var, int64_t max_count, int64_t min_consecutive = 1) {
     if (!IsValidDType(var->dtype)) {
@@ -455,11 +456,16 @@ public:
 
     int64_t count = 0;
     std::vector<int64_t> found_values;
+    bool result_unknown = false;
 
     while (count < max_count) {
       auto result = solver.check();
-      if (result != z3::sat) {
-        break;  // No more solutions
+      if (result == z3::unsat) {
+        break;  // No more solutions.
+      }
+      if (result == z3::unknown) {
+        result_unknown = true;
+        break;
       }
 
       z3::model m = solver.get_model();
@@ -489,6 +495,12 @@ public:
       MemoErase(expr);
     }
     side_effect_exprs_.clear();
+
+    // A partial model count is not an exact result. Keep UNSAT distinct: if
+    // the first check is UNSAT, count remains zero and is returned as such.
+    if (result_unknown) {
+      return -1;
+    }
 
     // Check minimum consecutive constraint if enabled
     if (min_consecutive > 0 && count > 0) {

--- a/tests/cpp/z3_prover_test.cc
+++ b/tests/cpp/z3_prover_test.cc
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <tvm/arith/analyzer.h>
+#include <tvm/ir/with_context.h>
+#include <tvm/tirx/op.h>
+
+namespace tvm::arith {
+
+TEST(Z3Prover, DistinguishesUnsatFromUnknown) {
+  Analyzer availability_probe;
+  if (availability_probe.z3_prover.GetStats() == "; Z3 Prover is disabled.") {
+    GTEST_SKIP() << "Z3 support is disabled";
+  }
+
+  tirx::Var var("value", DataType::Int(32));
+  Range domain =
+      Range::FromMinExtent(tirx::make_const(var.dtype(), 0), tirx::make_const(var.dtype(), 4));
+
+  Analyzer unsat_analyzer;
+  unsat_analyzer.Bind(var, domain);
+  {
+    With<ConstraintContext> constraint(&unsat_analyzer, var < 0);
+    EXPECT_EQ(unsat_analyzer.z3_prover.CountSatisfyingValues(var, 4), 0);
+  }
+
+  Analyzer unknown_analyzer;
+  unknown_analyzer.Bind(var, domain);
+  unknown_analyzer.z3_prover.SetRLimit(1);
+  EXPECT_EQ(unknown_analyzer.z3_prover.CountSatisfyingValues(var, 4), -1);
+}
+
+}  // namespace tvm::arith


### PR DESCRIPTION
Slightly changed the semantic of `CountSatisfyingValues` as shown in source code.

Now `CountSatisfyingValues` returns `-1` when encountering `Unknown` (possibly due to exceeding `rlimit` internal ticks).

The modified method was used 3 times in `Tilelang`:

- `src/backend/common/op/reduce.h:142` (temporarily fallbacked to `max - min + 1`)
- `src/transform/thread_storage_sync.cc:359`
```cpp
    int64_t z3_count =
        analyzer_->z3_prover.CountSatisfyingValues(iv->var, extent);
    if (z3_count > 0) {
      return static_cast<size_t>(z3_count);
    }

    // Fallback to range-based calculation if Z3 enumeration failed
    return static_cast<size_t>(bound->max_value - bound->min_value + 1);
```
- `src/transform/thread_storage_sync.cc:475`
```cpp
      With<arith::ConstraintContext> ctx(analyzer_, expr);
      auto count = analyzer_->z3_prover.CountSatisfyingValues(
          iv->var, thread_extent, /*min_consecutive=*/warp_size_);
      if (count < 0) {
        // ThreadPartialSyncRewriter cannot safely lower this condition.
        current_.requires_hoist = true;

```

They all fallback when `return code < 0`, which is the expected behavior when `CountSatisfyingValues` gives uncertain answers.