### PR TITLE
[Arith][Z3] Add scoped contexts for analyzers

### DIFF
--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -636,6 +636,20 @@ class IntSetAnalyzer {
   Impl* impl_;
 };
 
+/*!
+ * \brief Enter a thread-local Z3 context scope.
+ *
+ * The outermost scope creates a fresh Z3 context. Nested scopes on the same
+ * thread reuse that context so all Analyzers created during one compilation
+ * can share it.
+ */
+TVM_DLL void EnterZ3ContextScope();
+
+/*!
+ * \brief Exit the current thread-local Z3 context scope.
+ */
+TVM_DLL void ExitZ3ContextScope();
+
 class Z3Prover {
  public:
   /*!

--- a/python/tvm/arith/__init__.py
+++ b/python/tvm/arith/__init__.py
@@ -25,7 +25,7 @@ from .int_set import (
     estimate_region_strict_bound,
     estimate_region_upper_bound,
 )
-from .analyzer import ModularSet, ConstIntBound, Analyzer, ProofStrength, Extension
+from .analyzer import ModularSet, ConstIntBound, Analyzer, ProofStrength, Extension, Z3ContextScope
 from .bound import deduce_bound
 from .pattern import detect_linear_equation, detect_clip_bound
 from .int_solver import solve_linear_equations, solve_linear_inequalities

--- a/python/tvm/arith/analyzer.py
+++ b/python/tvm/arith/analyzer.py
@@ -100,6 +100,21 @@ class ConstraintScope:
         self._fexit()
 
 
+class Z3ContextScope:
+    """Share one fresh Z3 context across Analyzers created in this scope.
+
+    The outermost scope creates the context. Nested scopes on the same thread
+    reuse it, and exiting the outermost scope releases its ownership.
+    """
+
+    def __enter__(self):
+        _ffi_api.EnterZ3ContextScope()
+        return self
+
+    def __exit__(self, ptype, value, trace):
+        _ffi_api.ExitZ3ContextScope()
+
+
 class Analyzer:
     """Integer arithmetic analyzer
 
@@ -159,7 +174,7 @@ class Analyzer:
             The maximum number of steps.
         """
         self._set_z3_rlimit(max_step)
-    
+
     def get_z3_stats(self) -> str:
         """Get z3 statistics.
 

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -541,6 +541,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     auto self = std::make_shared<Analyzer>();
     *ret = BuildAnalyzerFactory(self);
   });
+  refl::GlobalDef().def_packed("arith.EnterZ3ContextScope",
+                               [](ffi::PackedArgs, ffi::Any*) { EnterZ3ContextScope(); });
+  refl::GlobalDef().def_packed("arith.ExitZ3ContextScope",
+                               [](ffi::PackedArgs, ffi::Any*) { ExitZ3ContextScope(); });
 }
 
 }  // namespace arith

--- a/src/target/z3/z3_prover_off.cc
+++ b/src/target/z3/z3_prover_off.cc
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #include <tvm/arith/analyzer.h>
 #include <tvm/tirx/expr.h>
 #include <tvm/tirx/op.h>
@@ -11,6 +30,9 @@ using namespace tirx;
 using namespace ffi;
 
 class Z3Prover::Impl {};
+
+void EnterZ3ContextScope() {}
+void ExitZ3ContextScope() {}
 
 TVM_DLL bool Z3Prover::CanProve(const PrimExpr & expr) { return false; }
 TVM_DLL void Z3Prover::Bind(const Var& var, const Range& new_range, bool allow_override) {}

--- a/src/target/z3/z3_prover_on.cc
+++ b/src/target/z3/z3_prover_on.cc
@@ -1,12 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #include <tvm/arith/analyzer.h>
+#include <tvm/ffi/extra/structural_equal.h>
+#include <tvm/ffi/extra/structural_hash.h>
 #include <tvm/runtime/logging.h>
-#include <tvm/tirx/expr.h>
-#include <tvm/tirx/op.h>
+#include <tvm/tirx/analysis.h>
 #include <tvm/tirx/builtin.h>
-#include "z3++.h"
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/expr_functor.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/op_attr_types.h>
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -17,13 +41,8 @@
 #include "tvm/ffi/object.h"
 #include "tvm/ffi/string.h"
 #include "tvm/ir/expr.h"
-#include <tvm/ffi/extra/structural_equal.h>
-#include <tvm/ffi/extra/structural_hash.h>
 #include "tvm/runtime/data_type.h"
-#include <tvm/tirx/analysis.h>
-#include <tvm/tirx/expr_functor.h>
-#include "tvm/arith/analyzer.h"
-#include <tvm/tirx/op_attr_types.h>
+#include "z3++.h"
 
 namespace tvm::arith {
 
@@ -64,7 +83,48 @@ struct Namespace {
   }
 };
 
-} // namespace
+struct Z3ContextState {
+  std::shared_ptr<z3::context> fallback_context;
+  std::shared_ptr<z3::context> scoped_context;
+  size_t scope_depth{0};
+};
+
+Z3ContextState& GetZ3ContextState() {
+  static thread_local Z3ContextState state;
+  return state;
+}
+
+std::shared_ptr<z3::context> GetCurrentZ3Context() {
+  auto& state = GetZ3ContextState();
+  if (state.scope_depth != 0) {
+    TVM_FFI_ICHECK(state.scoped_context != nullptr);
+    return state.scoped_context;
+  }
+  if (state.fallback_context == nullptr) {
+    state.fallback_context = std::make_shared<z3::context>();
+  }
+  return state.fallback_context;
+}
+
+}  // namespace
+
+void EnterZ3ContextScope() {
+  auto& state = GetZ3ContextState();
+  if (state.scope_depth == 0) {
+    state.scoped_context = std::make_shared<z3::context>();
+  }
+  ++state.scope_depth;
+}
+
+void ExitZ3ContextScope() {
+  auto& state = GetZ3ContextState();
+  TVM_FFI_ICHECK_GT(state.scope_depth, 0U)
+      << "ExitZ3ContextScope called without a matching EnterZ3ContextScope";
+  --state.scope_depth;
+  if (state.scope_depth == 0) {
+    state.scoped_context.reset();
+  }
+}
 
 class Z3Prover::Impl : ExprFunctor<z3::expr(const PrimExpr &)> {
 public:
@@ -73,13 +133,12 @@ public:
 
   Analyzer* analyzer;
   /// @brief Z3 context, a shared ptr, because tilelang want to copy the Analyzer
-  // We use a thread_local static Z3 context so all analyzers within the same thread
-  // can share a common context, because Z3 initialization is slow on some CPUs
-  // (e.g., AMD EPYC 7502 32-Core). Using thread_local ensures thread safety.
-  inline static thread_local std::shared_ptr<z3::context> ctx { new z3::context() };
+  // Analyzers created in one compile scope share a context. Keeping the pointer
+  // on each prover also lets cloned Analyzers safely outlive that scope.
+  std::shared_ptr<z3::context> ctx;
 
   /// @brief Z3 solver instance
-  z3::solver solver {*ctx};
+  std::optional<z3::solver> solver;
 
   /// @brief Memoized PrimExpr -> slot in z3_pool_. Holds no z3 handles, so
   /// its pointer-hashed bucket order cannot affect z3 object lifetime.
@@ -131,17 +190,17 @@ public:
 
   /// @brief Create a z3 solver with custom options
   static z3::solver CreateSolver(z3::context & ctx) {
-    z3::solver solver(ctx);
+    z3::solver result(ctx);
     // here we disable model generation to speed up the solving process
-    solver.set("model", false);
+    result.set("model", false);
     // ensure determinstic behavior
-    solver.set("random_seed", (unsigned)42);
-    return solver;
+    result.set("random_seed", (unsigned)42);
+    return result;
   }
 
-  Impl(Analyzer * parent): analyzer(parent) {
+  Impl(Analyzer* parent)
+      : analyzer(parent), ctx(GetCurrentZ3Context()), solver(CreateSolver(*ctx)) {
     scope_stack_.push_back({});
-    solver = CreateSolver(*ctx);
     // default timeout 5ms
     // Z3's implementation of timeout, when setting timeout T ms, it will stop at T - 1 ms
     // SetTimeoutMs(5);
@@ -161,11 +220,11 @@ public:
     else {
       z3::expr e = ctx->int_const(name.c_str());
       if(dtype.is_uint() && dtype.bits() == 64) {
-        solver.add(ctx->int_val(0) <= e && e <= ctx->int_val((uint64_t)UINT64_MAX));
+        solver->add(ctx->int_val(0) <= e && e <= ctx->int_val((uint64_t)UINT64_MAX));
       } else {
         auto min_val = Downcast<IntImm>(min_value(dtype))->value;
         auto max_val = Downcast<IntImm>(max_value(dtype))->value;
-        solver.add(ctx->int_val(min_val) <= e && e <= ctx->int_val(max_val));
+        solver->add(ctx->int_val(min_val) <= e && e <= ctx->int_val(max_val));
       }
       return e;
     }
@@ -193,15 +252,15 @@ public:
     if (!IsValidDType(constraint->dtype)) return nullptr;
     scope_stack_.push_back({});
     scope_stack_.back().push_back(Scope{Scope::Constraint, Var(), PrimExpr(), PrimExpr(), PrimExpr(), constraint});
-    solver.push();
+    solver->push();
     this->is_assume = is_assume;
-    solver.add(VisitBool(constraint));
+    solver->add(VisitBool(constraint));
     this->is_assume = false;
     auto side_effect_exprs = std::move(side_effect_exprs_);
     side_effect_exprs_.clear();
     if(is_assume) {
       return [this, side_effect_exprs]() {
-        solver.pop();
+        solver->pop();
         for (const auto& expr : side_effect_exprs) {
           MemoErase(expr);
         }
@@ -212,7 +271,7 @@ public:
         MemoErase(expr);
       }
       return [this]() {
-        solver.pop();
+        solver->pop();
         scope_stack_.pop_back();
       };
     }
@@ -267,7 +326,7 @@ public:
     if (!IsValidDType(expr->dtype)) return false;
     z3::expr_vector constr(*ctx);
     constr.push_back(!ConvertBool(expr));
-    auto result = solver.check(constr);
+    auto result = solver->check(constr);
     constr.pop_back();
     return result == z3::unsat;
   }
@@ -308,23 +367,26 @@ public:
       int64_t min_value = *tirx::as_const_int(range->min);
       int64_t max_value = *tirx::as_const_int(range->min + range->extent);
       if(min_value < max_value) {
-        solver.add(ctx->int_val(min_value) <= var_expr);
-        solver.add(var_expr < ctx->int_val(max_value));
+        solver->add(ctx->int_val(min_value) <= var_expr);
+        solver->add(var_expr < ctx->int_val(max_value));
       }
     } else {
-      solver.add(ConvertBool(range->extent <= 0 || (range->min <= var && var < range->min + range->extent)));
+      solver->add(ConvertBool(range->extent <= 0 ||
+                              (range->min <= var && var < range->min + range->extent)));
     }
   }
 
   void CopyFrom(const Self & other_) {
-    // 1. create a new solver
-    //    because this->solver depends on this->ctx
-    //    we need to deconstruct the old solver, and create a new one depending on other_.ctx
-    solver = CreateSolver(*other_.ctx);
-    // 2. copy the context
-    //    the context is a shared_ptr, we can just copy the pointer
+    // Z3 handles cannot move between contexts. Destroy every handle owned by
+    // this fresh clone before adopting the source Analyzer's context.
+    solver.reset();
+    memo_.clear();
+    z3_pool_.clear();
+    free_slots_.clear();
     ctx = other_.ctx;
-    // 3. copy other objects
+    solver.emplace(CreateSolver(*ctx));
+
+    // Copy other objects.
     ns = other_.ns;
     // Replay live memo entries in slot order: deterministic, unlike the
     // pointer-hashed iteration order of memo_ itself.
@@ -334,27 +396,26 @@ public:
     std::sort(live.begin(), live.end(),
               [](auto &a, auto &b) { return a.first < b.first; });
     for (auto &[idx, e] : live) MemoPut(*e, *other_.z3_pool_[idx]);
-    for(auto a: other_.solver.assertions()) {
-      solver.add(a);
+    for (auto a : other_.solver->assertions()) {
+      solver->add(a);
     }
-    // 4. copy timeout options
-    //    but other solver options are not copied
+    // Copy timeout options, but not other solver options.
     SetTimeoutMs(other_.timeout_ms);
     SetRLimit(other_.rlimit);
-    // 5. copy the scope stack, which containing comments for SMTLIB2 generation
+    // Copy the scope stack, which contains comments for SMTLIB2 generation.
     scope_stack_ = other_.scope_stack_;
   }
 
   /// @brief Set timeout in milliseconds
   void SetTimeoutMs(unsigned timeout_ms) {
     this->timeout_ms = timeout_ms;
-    solver.set("timeout", timeout_ms);
+    solver->set("timeout", timeout_ms);
   }
 
   /// @brief Set max steps
   void SetRLimit(unsigned rlimit) {
     this->rlimit = rlimit;
-    solver.set("rlimit", rlimit);
+    solver->set("rlimit", rlimit);
   }
 
   /// @brief Get the SMTLIB2 representation of the current solver state
@@ -362,7 +423,7 @@ public:
     std::stringstream ss;
     ss << "(set-option :timeout " << timeout_ms << ")\n";
     AddScopeDebugMsg(ss);
-    ss <<  solver.to_smt2();
+    ss << solver->to_smt2();
     return ss.str();
   }
 
@@ -391,28 +452,28 @@ public:
     ss << "(set-option :timeout " << timeout_ms << ")\n";
     AddScopeDebugMsg(ss);
     ss << "; Trying to prove: " << expr << "\n";
-    solver.push();
-    solver.add(!ConvertBool(expr));
-    ss << solver.to_smt2();
-    solver.pop();
+    solver->push();
+    solver->add(!ConvertBool(expr));
+    ss << solver->to_smt2();
+    solver->pop();
     return ss.str();
   }
 
   /// @brief Get the statistics of the solver
   ffi::String GetStats() {
     std::stringstream ss;
-    ss << solver.statistics();
+    ss << solver->statistics();
     return ss.str();
   }
 
   ffi::String GetModel(const PrimExpr & expr) {
-    solver.set("model", true);
-    solver.push();
-    solver.add(!ConvertBool(expr));
-    auto result = solver.check();
+    solver->set("model", true);
+    solver->push();
+    solver->add(!ConvertBool(expr));
+    auto result = solver->check();
     ffi::String model_str;
     if (result == z3::sat) {
-      z3::model m = solver.get_model();
+      z3::model m = solver->get_model();
       std::map<std::string, z3::expr> model_map;
       for(unsigned i = 0; i < m.size(); i++) {
         z3::func_decl d = m[i];
@@ -424,8 +485,8 @@ public:
       }
       model_str = ss.str();
     }
-    solver.pop();
-    solver.set("model", false);
+    solver->pop();
+    solver->set("model", false);
     return model_str;
   }
 
@@ -447,8 +508,8 @@ public:
       return -1;
     }
 
-    solver.set("model", true);
-    solver.push();
+    solver->set("model", true);
+    solver->push();
 
     // Convert the TVM variable to Z3 expression
     z3::expr z3_var = VisitInt(var);
@@ -457,12 +518,12 @@ public:
     std::vector<int64_t> found_values;
 
     while (count < max_count) {
-      auto result = solver.check();
+      auto result = solver->check();
       if (result != z3::sat) {
         break;  // No more solutions
       }
 
-      z3::model m = solver.get_model();
+      z3::model m = solver->get_model();
       z3::expr val_expr = m.eval(z3_var, true);
 
       // Extract the integer value from Z3 expression
@@ -478,11 +539,11 @@ public:
       count++;
 
       // Add blocking clause: var != val (exclude this solution)
-      solver.add(z3_var != ctx->int_val(val));
+      solver->add(z3_var != ctx->int_val(val));
     }
 
-    solver.pop();
-    solver.set("model", false);
+    solver->pop();
+    solver->set("model", false);
 
     // Clear any side effects from visiting the variable
     for (const auto& expr : side_effect_exprs_) {
@@ -743,11 +804,11 @@ private:
 
       // Add constraint that shift amount should be non-negative
       // This is a common assumption in many programming languages
-      solver.add(b_expr >= 0);
+      solver->add(b_expr >= 0);
 
       // Also limit shift amount to avoid unrealistic large shifts
       // We'll limit to 64 bits (reasonable for most use cases)
-      solver.add(b_expr < 64);
+      solver->add(b_expr < 64);
 
       unsigned bit_width = std::max(a.dtype().bits(), b.dtype().bits());
       z3::expr a_bv = z3::int2bv(bit_width, a_expr);

--- a/tests/python/arith/test_arith_simplify.py
+++ b/tests/python/arith/test_arith_simplify.py
@@ -181,5 +181,22 @@ def test_vector_constraint_does_not_crash_z3():
         tvm.ir.assert_structural_equal(ana.simplify(x + 0), x)
 
 
+def test_z3_context_scope_clone_lifetime():
+    x = tirx.Var("x", "int32")
+
+    with tvm.arith.Z3ContextScope():
+        analyzer = tvm.arith.Analyzer()
+        analyzer.bind(x, tvm.ir.Range.from_min_extent(0, 16))
+
+    # Clone while a different scope is active.  The clone must retain the
+    # source Analyzer's context instead of mixing handles from two contexts.
+    with tvm.arith.Z3ContextScope():
+        cloned = analyzer.clone()
+
+    del analyzer
+    assert cloned.can_prove(x >= 0)
+    assert cloned.can_prove(x < 16)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
## Summary

A persistent thread-local Z3 context lets resource usage and AST history accumulate across otherwise independent compilations. This change adds an explicit context boundary while retaining context sharing within one compilation.

- add an explicit Z3 context scope for groups of `Analyzer` instances
- isolate independent compilations from Z3 state accumulated by earlier kernels
- preserve existing behavior for callers that do not opt into a scope

## Implementation

- expose `EnterZ3ContextScope` and `ExitZ3ContextScope` through FFI and add `tvm.arith.Z3ContextScope`
- create a fresh thread-local context at the outermost scope and share it with nested scopes
- retain shared context ownership in each prover so analyzers and clones remain valid after a scope exits
- rebuild cloned solver state only after adopting the source analyzer context
- provide no-op scope hooks when Z3 is disabled
- add a regression test for cloning across scope lifetimes

## Validation

- Z3-enabled integration build
- `python -m pytest -q tests/python/arith/test_arith_simplify.py -k "not vscale"` (30 passed, 5 deselected)
- downstream multi-kernel compilation regression (7 passed)
- changed-line clang-format check
- Ruff lint and format checks on changed Python files