### PR TITLE
[Arith] Preserve non-divisible nested floormod

### DIFF
--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -2009,6 +2009,11 @@ PrimExpr IterMapRewriter::SplitFloorModConst(IterSplitExpr lhs, PrimExpr base, P
 
   // We handle scale!=1 in above code, hence we only consider floormod(x, rhs) below
   // where x=floormod(floordiv(iter, lower_factor), extent) + base
+  bool inner_mod_can_wrap =
+      !analyzer_->CanProve(lhs->source->extent <= lhs->lower_factor * lhs->extent);
+  if (inner_mod_can_wrap && !CanProveDivisible(lhs->extent, rhs)) {
+    return PrimExpr();
+  }
   auto pair = PadDividendToDivisor(lhs, base, rhs);
   IterSplitExpr padded = pair.first;
   if (!padded.defined()) {

--- a/tests/python/arith/test_arith_iter_affine_map.py
+++ b/tests/python/arith/test_arith_iter_affine_map.py
@@ -235,6 +235,18 @@ def test_compound_floormod_two_regression():
     )
 
 
+def test_nested_floormod_requires_divisible_extents():
+    x = tvm.tirx.Var("x", "int32")
+    flm = tvm.tirx.floormod
+    dom_map = var_dom([(x, 128)])
+
+    non_divisible = flm(flm(x, 64), 7)
+    assert_iter_map_simplify({non_divisible: non_divisible}, dom_map)
+
+    divisible = flm(flm(x, 64), 8)
+    assert_iter_map_simplify({divisible: flm(x, 8)}, dom_map)
+
+
 def test_predicate():
     x = tvm.tirx.Var("x", "int32")
     y = tvm.tirx.Var("y", "int32")


### PR DESCRIPTION
## Summary

- keep a nested `floormod` when the inner split can wrap and its extent is not divisible by the outer modulus
- preserve the existing simplification for non-wrapping or provably divisible cases
- add regression coverage for both `x % 64 % 7` and `x % 64 % 8`

Padding the inner extent cannot justify dropping an active inner modulo because the wrapped expression never produces the padded values.

Related to tile-ai/tilelang#2955.

## Testing

- `cmake --build build -j12`
- `pytest tests/python/arith/test_arith_iter_affine_map.py -q` — 39 passed
- TileLang mirrored arithmetic suite — 39 passed