### PR TITLE
[BugFix][Arith] Preserve nested floormod semantics across padding

### DIFF
--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -2009,6 +2009,11 @@ PrimExpr IterMapRewriter::SplitFloorModConst(IterSplitExpr lhs, PrimExpr base, P
 
   // We handle scale!=1 in above code, hence we only consider floormod(x, rhs) below
   // where x=floormod(floordiv(iter, lower_factor), extent) + base
+  bool inner_mod_can_wrap =
+      !analyzer_->CanProve(lhs->source->extent <= lhs->lower_factor * lhs->extent);
+  if (inner_mod_can_wrap && !CanProveDivisible(lhs->extent, rhs)) {
+    return PrimExpr();
+  }
   auto pair = PadDividendToDivisor(lhs, base, rhs);
   IterSplitExpr padded = pair.first;
   if (!padded.defined()) {

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -2009,8 +2009,20 @@ PrimExpr IterMapRewriter::SplitFloorModConst(IterSplitExpr lhs, PrimExpr base, P
 
   // We handle scale!=1 in above code, hence we only consider floormod(x, rhs) below
   // where x=floormod(floordiv(iter, lower_factor), extent) + base
+  PrimExpr source_upper_bound = lhs->source->extent;
+  auto origin_it = padded_origin_map_.find(lhs->source);
+  if (origin_it != padded_origin_map_.end()) {
+    auto padding_it = padded_iter_map_.find(origin_it->second);
+    TVM_FFI_ICHECK(padding_it != padded_iter_map_.end());
+    // Right padding only contains values excluded by padding_predicate_, so it
+    // cannot make the inner floormod wrap over the original iterator domain.
+    // Keep left-padded marks conservative because padding shifts their values.
+    if (is_zero(padding_it->second.left_pad)) {
+      source_upper_bound = origin_it->second->extent;
+    }
+  }
   bool inner_mod_can_wrap =
-      !analyzer_->CanProve(lhs->source->extent <= lhs->lower_factor * lhs->extent);
+      !analyzer_->CanProve(source_upper_bound <= lhs->lower_factor * lhs->extent);
   if (inner_mod_can_wrap && !CanProveDivisible(lhs->extent, rhs)) {
     return PrimExpr();
   }

--- a/tests/python/arith/test_arith_iter_affine_map.py
+++ b/tests/python/arith/test_arith_iter_affine_map.py
@@ -235,6 +235,18 @@ def test_compound_floormod_two_regression():
     )
 
 
+def test_nested_floormod_requires_divisible_extents():
+    x = tvm.tirx.Var("x", "int32")
+    flm = tvm.tirx.floormod
+    dom_map = var_dom([(x, 128)])
+
+    non_divisible = flm(flm(x, 64), 7)
+    assert_iter_map_simplify({non_divisible: non_divisible}, dom_map)
+
+    divisible = flm(flm(x, 64), 8)
+    assert_iter_map_simplify({divisible: flm(x, 8)}, dom_map)
+
+
 def test_predicate():
     x = tvm.tirx.Var("x", "int32")
     y = tvm.tirx.Var("y", "int32")

--- a/tests/python/arith/test_arith_iter_affine_map.py
+++ b/tests/python/arith/test_arith_iter_affine_map.py
@@ -238,13 +238,27 @@ def test_compound_floormod_two_regression():
 def test_nested_floormod_requires_divisible_extents():
     x = tvm.tirx.Var("x", "int32")
     flm = tvm.tirx.floormod
-    dom_map = var_dom([(x, 128)])
-
     non_divisible = flm(flm(x, 64), 7)
-    assert_iter_map_simplify({non_divisible: non_divisible}, dom_map)
+
+    # The inner floormod does not wrap at or below its exact domain boundary.
+    assert_iter_map_simplify({non_divisible: flm(x, 7)}, var_dom([(x, 63)]))
+    assert_iter_map_simplify({non_divisible: flm(x, 7)}, var_dom([(x, 64)]))
+
+    # One value beyond the boundary makes the non-divisible inner floormod observable.
+    assert_iter_map_simplify({non_divisible: non_divisible}, var_dom([(x, 65)]))
+    assert_iter_map_simplify({non_divisible: non_divisible}, var_dom([(x, 128)]))
+
+    # A non-zero domain minimum becomes left padding.  Keep these cases
+    # conservative because padding shifts the iterator values.
+    assert_iter_map_simplify(
+        {non_divisible: non_divisible}, {x: tvm.ir.Range.from_min_extent(1, 63)}
+    )
+    assert_iter_map_simplify(
+        {non_divisible: non_divisible}, {x: tvm.ir.Range.from_min_extent(1, 64)}
+    )
 
     divisible = flm(flm(x, 64), 8)
-    assert_iter_map_simplify({divisible: flm(x, 8)}, dom_map)
+    assert_iter_map_simplify({divisible: flm(x, 8)}, var_dom([(x, 128)]))
 
 
 def test_predicate():


### PR DESCRIPTION
## Summary

- Prevent an unsound nested `floormod` collapse when the inner modulus can wrap and is not divisible by the outer modulus.
- Preserve the valid no-wrap simplification when surjective iter-map rewriting introduces right padding only.
- Keep left-padded iterator marks conservative because padding shifts their coordinate values.

Related to tile-ai/tilelang#2955. Builds on #64.

## Changes

- Gate `SplitFloorModConst` on the real source-domain wrap condition and modulus divisibility.
- Recover the original source extent through `padded_origin_map_` only when no left padding was introduced.
- Add boundary coverage for source extents 63, 64, 65, and 128, left-padded domains, and the divisible control case.

## Validation

- `python -m pytest tests/python/arith/test_arith_iter_affine_map.py -q` — 39 passed.
- TileLang mirrored arithmetic suite — 39 passed.
- TileLang GPU reproduction for `K=7` and `K=8` — 0 mismatches out of 1024 outputs in both cases.
- 50,000 randomized non-divisible cases covering 337,872 concrete values — no semantic mismatches.
- `ruff-check`, `ruff-format`, and `clang-format` pre-commit hooks passed.

## Notes

Only right padding is ignored when proving that the inner modulus cannot wrap. Left-padded domains remain intentionally conservative to avoid treating shifted padding coordinates as original iterator values.
