### PR TITLE
[BugFix][Arith] Reject cyclic floormod normalization in bijective maps

### DIFF
--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -2032,6 +2032,18 @@ PrimExpr IterMapRewriter::SplitFloorModConst(IterSplitExpr lhs, PrimExpr base, P
     return PrimExpr();
   }
 
+  // An offset whose modulo phase is not zero rotates the values around the
+  // modulo domain.  The current IterSplit representation does not retain that
+  // rotation, and InverseAffineIterMap would therefore invert
+  // (x + base) % rhs as x % rhs.  Padding-aware modes preserve the original
+  // expression through a padded IterMark, but a bijective rewrite has no such
+  // metadata.  Reject it instead of returning a semantically different map.
+  if (check_level_ == IterMapLevel::Bijective && !analyzer_->CanProveEqual(pair.second, 0)) {
+    ErrorLogger(this) << "Cannot represent as a bijective IterMap: FloorMod offset " << base
+                      << " may induce a cyclic shift modulo " << rhs;
+    return PrimExpr();
+  }
+
   // floormod(floormod(floordiv(iter, lower_factor), c1c2), c1)
   // = floormod(floordiv(iter, lower_factor), c1), where c1=rhs
   return IterSplitExpr(padded->source,

--- a/tests/python/arith/test_arith_iter_affine_map.py
+++ b/tests/python/arith/test_arith_iter_affine_map.py
@@ -261,6 +261,21 @@ def test_nested_floormod_requires_divisible_extents():
     assert_iter_map_simplify({divisible: flm(x, 8)}, var_dom([(x, 128)]))
 
 
+def test_bijective_floormod_rejects_cyclic_offset():
+    x = tvm.tirx.Var("x", "int32")
+    flm = tvm.tirx.floormod
+    dom_map = var_dom([(x, 128)])
+
+    cyclic_shift = flm(x + 1, 128)
+    assert_iter_sum_failure([cyclic_shift], dom_map, check_level="bijective")
+    assert_iter_map_simplify({cyclic_shift: cyclic_shift}, dom_map, check_level="bijective")
+    assert_iter_map_simplify({cyclic_shift: cyclic_shift}, dom_map)
+
+    # An offset divisible by the modulus does not change the mapping.
+    wrapped_identity = flm(x + 128, 128)
+    assert_iter_sum_pattern({wrapped_identity: (128, 0)}, dom_map, check_level="bijective")
+
+
 def test_predicate():
     x = tvm.tirx.Var("x", "int32")
     y = tvm.tirx.Var("y", "int32")


### PR DESCRIPTION
## Summary

- Prevent DetectIterMap(..., Bijective) from silently normalizing a shifted modulo expression to an unshifted one when the offset has a non-zero modulo phase.
- Reject the unsupported cyclic rotation instead of returning an IterMap that InverseAffineIterMap would invert incorrectly.
- Preserve existing behavior for offsets divisible by the modulus and for padding-aware non-bijective simplification.

Related to tile-ai/tilelang#2948 and tile-ai/tilelang#3090.

## Root cause

VisitExpr_(AddNode) stores the offset in IterSumExpr::base. SplitFloorModConst computes that phase as pair.second, but the bijective path has no padded IterMark carrying it and returns only pair.first. The resulting normalized map is therefore semantically different:

    (x + 1) % 128  ->  x

InverseAffineIterMap then sees an unshifted split and produces x = output.

## Validation

Before the fix, the regression test failed because the cyclic shift produced one accepted bijective index.

After the fix:

- cmake --build build -j 32
- PYTHONPATH=$PWD/python TVM_LIBRARY_PATH=$PWD/build python3 -m pytest -q -p no:tvm.testing.plugin tests/python/arith/test_arith_iter_affine_map.py — 40 passed
- python3 -m ruff check tests/python/arith/test_arith_iter_affine_map.py
- python3 -m ruff format --check tests/python/arith/test_arith_iter_affine_map.py
- clang-format --dry-run --Werror src/arith/iter_affine_map.cc
- git diff --check

The repository-wide ASF-header pre-commit hook reports 11 pre-existing missing headers outside this change; all relevant formatting and lint hooks pass.
