### PR TITLE
[Perf][Arith] Materialize Z3 solvers lazily on first query

### DIFF
--- a/src/target/z3/z3_prover_on.cc
+++ b/src/target/z3/z3_prover_on.cc
@@ -199,8 +199,16 @@ public:
   }
 
   Impl(Analyzer* parent)
-      : analyzer(parent), ctx(GetCurrentZ3Context()), solver(CreateSolver(*ctx)) {
+      : analyzer(parent), ctx(GetCurrentZ3Context()) {
+    // The solver is created lazily (see Materialize). Analyzers are
+    // constructed in large numbers as cheap scratch objects, and only a tiny
+    // fraction ever reaches the Z3 fallback of CanProve; creating the solver
+    // (and translating every Bind into z3 constraints) eagerly made every
+    // Analyzer pay Z3's initialization cost up front. Until the first
+    // operation that actually needs the solver, Bind/EnterConstraint only
+    // journal their arguments into scope_stack_.
     scope_stack_.push_back({});
+    scope_side_effects_.push_back({});
     // default timeout 5ms
     // Z3's implementation of timeout, when setting timeout T ms, it will stop at T - 1 ms
     // SetTimeoutMs(5);
@@ -208,8 +216,48 @@ public:
     SetRLimit(1e4);
   }
 
+  /// @brief Create the solver on first use and replay the recorded journal.
+  ///
+  /// The live scope_stack_ (which also feeds the SMTLIB2 debug output) holds
+  /// exactly the binds and constraints an eagerly-built solver would carry:
+  /// binds append to the innermost scope and scopes pop LIFO, so walking the
+  /// scopes front-to-back replays the surviving entries in the order they
+  /// were recorded. Entries from scopes that already exited were popped
+  /// together with their scope and are correctly absent. The replay performs
+  /// the same MemoPut/solver->add sequence the eager path would have done
+  /// for these entries, so CanProve answers are unchanged.
+  void Materialize() {
+    if (solver) return;
+    solver.emplace(CreateSolver(*ctx));
+    if (timeout_ms != UINT_MAX) {
+      solver->set("timeout", timeout_ms);
+    }
+    if (rlimit != UINT_MAX) {
+      solver->set("rlimit", rlimit);
+    }
+    TVM_FFI_ICHECK_EQ(scope_side_effects_.size(), scope_stack_.size());
+    for (size_t si = 0; si < scope_stack_.size(); ++si) {
+      for (const Scope& s : scope_stack_[si]) {
+        switch (s.kind) {
+          case Scope::BindValue:
+            ApplyBindValue(s.var, s.value);
+            break;
+          case Scope::BindRange:
+            ApplyBindRange(s.var, s.min, s.extent);
+            break;
+          case Scope::Constraint:
+            ApplyConstraint(s.constraint, s.is_assume, si);
+            break;
+        }
+      }
+    }
+  }
+
   /// @brief Create a Free z3 expression from PrimExprNode
   z3::expr Create(const PrimExprNode *op) {
+    // Expression translation only happens with a live solver: every public
+    // entry point that can reach a visitor materializes first.
+    TVM_FFI_ICHECK(solver.has_value());
     auto ref = ffi::GetRef<PrimExpr>(op);
     auto dtype = op->dtype;
     std::string name = ns.GetNewName(ref);
@@ -241,17 +289,50 @@ public:
     PrimExpr min;
     PrimExpr extent;
     PrimExpr constraint;
+    /// Assume-mode constraints keep the free variables they introduce
+    /// memoized for the lifetime of their scope; recorded so a deferred
+    /// replay reproduces the same memo behavior.
+    bool is_assume = false;
   };
 
   /// @brief scope_stack memorizes existing constraint and bindings
   ///        to generate SMTLIB2 representation with comments
   std::vector<std::vector<Scope>> scope_stack_;
 
+  /// @brief Per-scope memoized side-effect exprs (parallel to scope_stack_).
+  /// An assume-mode constraint keeps the free variables it introduces in the
+  /// memo until its scope exits; the exit callback erases whatever this
+  /// stack's top holds, which stays correct whether the constraint was
+  /// translated when it was entered or later, during a deferred replay.
+  std::vector<std::vector<PrimExpr>> scope_side_effects_;
+
   /// @brief Enter a constraint scope
   std::function<void()> EnterConstraint(const PrimExpr& constraint, bool is_assume=false) {
     if (!IsValidDType(constraint->dtype)) return nullptr;
     scope_stack_.push_back({});
-    scope_stack_.back().push_back(Scope{Scope::Constraint, Var(), PrimExpr(), PrimExpr(), PrimExpr(), constraint});
+    scope_stack_.back().push_back(Scope{Scope::Constraint, Var(), PrimExpr(), PrimExpr(), PrimExpr(), constraint, is_assume});
+    scope_side_effects_.push_back({});
+    if (solver) {
+      ApplyConstraint(constraint, is_assume, scope_side_effects_.size() - 1);
+    }
+    // Exit callback: scopes leave LIFO, so the stack tops are this scope's.
+    // If the solver materialized while the scope was live, the replay pushed
+    // a frame for it (and recorded any assume-kept side effects), so the pop
+    // and the memo erasure below stay balanced either way.
+    return [this]() {
+      if (solver) solver->pop();
+      for (const auto& expr : scope_side_effects_.back()) {
+        MemoErase(expr);
+      }
+      scope_side_effects_.pop_back();
+      scope_stack_.pop_back();
+    };
+  }
+
+  /// @brief Translate a constraint into the solver (push + assert). Assume
+  /// mode keeps introduced free vars memoized for the scope's lifetime by
+  /// parking them in scope_side_effects_[scope_index].
+  void ApplyConstraint(const PrimExpr& constraint, bool is_assume, size_t scope_index) {
     solver->push();
     this->is_assume = is_assume;
     solver->add(VisitBool(constraint));
@@ -259,21 +340,12 @@ public:
     auto side_effect_exprs = std::move(side_effect_exprs_);
     side_effect_exprs_.clear();
     if(is_assume) {
-      return [this, side_effect_exprs]() {
-        solver->pop();
-        for (const auto& expr : side_effect_exprs) {
-          MemoErase(expr);
-        }
-        scope_stack_.pop_back();
-      };
+      auto& keep = scope_side_effects_[scope_index];
+      keep.insert(keep.end(), side_effect_exprs.begin(), side_effect_exprs.end());
     } else {
       for(const auto & expr: side_effect_exprs) {
         MemoErase(expr);
       }
-      return [this]() {
-        solver->pop();
-        scope_stack_.pop_back();
-      };
     }
   }
 
@@ -322,8 +394,11 @@ public:
 
   /// @brief Check if the expression can be proved
   bool CanProve(const PrimExpr &expr) {
-    if (CheckTrivilBadCases(expr)) return false;
     if (!IsValidDType(expr->dtype)) return false;
+    // The trivial-bad-case check below consults the memo (IsFreeNode), so
+    // the journal must be replayed first for it to see the bound vars.
+    Materialize();
+    if (CheckTrivilBadCases(expr)) return false;
     z3::expr_vector constr(*ctx);
     constr.push_back(!ConvertBool(expr));
     auto result = solver->check(constr);
@@ -340,6 +415,11 @@ public:
       var,
       value
     });
+    if (!solver) return;  // journaled; translated when the solver materializes
+    ApplyBindValue(var, value);
+  }
+
+  void ApplyBindValue(const Var & var, const PrimExpr & value) {
     // we add the binding whenever the value is pure,
     // because non-pure parts are handling by creating free variables in VisitExpr
     MemoPut(var, ConvertInt(value));
@@ -355,6 +435,11 @@ public:
       range->min,
       range->extent
     });
+    if (!solver) return;  // journaled; translated when the solver materializes
+    ApplyBindRange(var, range->min, range->extent);
+  }
+
+  void ApplyBindRange(const Var & var, const PrimExpr & min, const PrimExpr & extent) {
     // 1. Create a placeholder for the var, and save it in the memo
     //    if the var is overrided later, we can just update the memo, and the old placeholder will be ignored
     auto var_expr = Create(var.as<PrimExprNode>());
@@ -363,20 +448,37 @@ public:
     // 2. Add constraint on the placeholder
     //    when min_expr >= max_expr, the range is empty, which is under undefined behavior
     //    instead of adding an unsat constraint, we just skip the range constraint to leave it a free var
-    if(tirx::is_const_int(range->min) && tirx::is_const_int(range->min + range->extent)) {
-      int64_t min_value = *tirx::as_const_int(range->min);
-      int64_t max_value = *tirx::as_const_int(range->min + range->extent);
+    if(tirx::is_const_int(min) && tirx::is_const_int(min + extent)) {
+      int64_t min_value = *tirx::as_const_int(min);
+      int64_t max_value = *tirx::as_const_int(min + extent);
       if(min_value < max_value) {
         solver->add(ctx->int_val(min_value) <= var_expr);
         solver->add(var_expr < ctx->int_val(max_value));
       }
     } else {
-      solver->add(ConvertBool(range->extent <= 0 ||
-                              (range->min <= var && var < range->min + range->extent)));
+      solver->add(ConvertBool(extent <= 0 ||
+                              (min <= var && var < min + extent)));
     }
   }
 
   void CopyFrom(const Self & other_) {
+    if (!other_.solver) {
+      // The source has not materialized: its entire Z3 state is the journal.
+      // Copy it and stay lazy; a later Materialize on this clone rebuilds
+      // the same solver state the source would have built.
+      solver.reset();
+      memo_.clear();
+      z3_pool_.clear();
+      free_slots_.clear();
+      ns = Namespace();
+      side_effect_exprs_.clear();
+      ctx = other_.ctx;
+      scope_stack_ = other_.scope_stack_;
+      scope_side_effects_.assign(scope_stack_.size(), {});
+      timeout_ms = other_.timeout_ms;
+      rlimit = other_.rlimit;
+      return;
+    }
     // Z3 handles cannot move between contexts. Destroy every handle owned by
     // this fresh clone before adopting the source Analyzer's context.
     solver.reset();
@@ -404,22 +506,26 @@ public:
     SetRLimit(other_.rlimit);
     // Copy the scope stack, which contains comments for SMTLIB2 generation.
     scope_stack_ = other_.scope_stack_;
+    scope_side_effects_ = other_.scope_side_effects_;
   }
 
   /// @brief Set timeout in milliseconds
   void SetTimeoutMs(unsigned timeout_ms) {
     this->timeout_ms = timeout_ms;
+    if (!solver) return;  // stored; applied when the solver materializes
     solver->set("timeout", timeout_ms);
   }
 
   /// @brief Set max steps
   void SetRLimit(unsigned rlimit) {
     this->rlimit = rlimit;
+    if (!solver) return;  // stored; applied when the solver materializes
     solver->set("rlimit", rlimit);
   }
 
   /// @brief Get the SMTLIB2 representation of the current solver state
   ffi::String GetSMTLIB2() {
+    Materialize();
     std::stringstream ss;
     ss << "(set-option :timeout " << timeout_ms << ")\n";
     AddScopeDebugMsg(ss);
@@ -448,6 +554,7 @@ public:
 
   /// @brief Get the SMTLIB2 representation of the current solver state with additional expr trying to prove
   ffi::String GetSMTLIB2(const PrimExpr & expr) {
+    Materialize();
     std::stringstream ss;
     ss << "(set-option :timeout " << timeout_ms << ")\n";
     AddScopeDebugMsg(ss);
@@ -461,12 +568,14 @@ public:
 
   /// @brief Get the statistics of the solver
   ffi::String GetStats() {
+    Materialize();
     std::stringstream ss;
     ss << solver->statistics();
     return ss.str();
   }
 
   ffi::String GetModel(const PrimExpr & expr) {
+    Materialize();
     solver->set("model", true);
     solver->push();
     solver->add(!ConvertBool(expr));
@@ -508,6 +617,7 @@ public:
       return -1;
     }
 
+    Materialize();
     solver->set("model", true);
     solver->push();
 


### PR DESCRIPTION
## Motivation

`Z3Prover::Impl` creates a `z3::solver` eagerly in its constructor, and `Analyzer::Bind` / `EnterConstraint` translate every binding into z3 constraints up front. `arith::Analyzer` is treated as a cheap scratch object all over the stack (`InverseWithLevel`, `OutputShape`, per-op inference analyzers, ...), so a single reducer-heavy tilelang kernel compile ends up creating **~67k Z3 solvers** and issuing **~100k z3 asserts** — while instrumentation shows only **~0.3% of analyzers ever reach the Z3 fallback** of `CanProve` (and in these compiles the fallback proves nothing at all). Profiling shows `init_solver_core` + `Z3Prover::Impl::Bind/Create` account for 40%+ of the whole compile.

## What this PR does

- The constructor no longer creates a solver. `Bind`/`EnterConstraint` only journal their arguments into `scope_stack_`, which already recorded every bind/constraint for the SMTLIB2 debug output (`Scope` gains an `is_assume` field).
- The first operation that actually needs the solver — `CanProve`, `GetSMTLIB2`, `GetModel`, `GetStats`, `CountSatisfyingValues` — calls `Materialize()`: create the solver, apply the stored timeout/rlimit, and replay the live journal in order. Binds append to the innermost scope and scopes pop LIFO, so walking `scope_stack_` front-to-back replays surviving entries in recording order; the translation bodies (`ApplyBindValue`/`ApplyBindRange`/`ApplyConstraint`) are the former eager code, unchanged.
- `CanProve` materializes before `CheckTrivilBadCases` because `IsFreeNode` consults the memo, which only reflects binds after replay.
- Assume-mode constraints keep their introduced free vars memoized for the scope's lifetime. That bookkeeping moves from lambda-captured lists to a `scope_side_effects_` stack parallel to `scope_stack_`, so the scope-exit callback erases the right entries whether the constraint was translated at entry or later during a deferred replay.
- `CopyFrom` copies the journal and stays lazy when the source is unmaterialized (the common case now); it keeps the existing assertion-replay path when the source already has a solver.

## Results

On a suite of 17 downstream reducer-heavy production kernels (H100, cold compiles, kernel cache disabled), the worst regressors improve 40-60% end-to-end:

| kernel (end-to-end, incl. ~6.6s fixed test overhead) | before | after |
|---|---|---|
| reducer kernel #1 | 23.7s | **12.9s** |
| reducer kernel #2 | 18.8s | **11.2s** |
| reducer kernel #3 | 14.3s | **10.5s** |

`tilelang.lower` roughly halves across the board (toy GEMM 0.23s → 0.13s, elementwise 0.18s → 0.06s).

## Validation

- tilelang language suite: 1168 passed, 137 skipped; reducer_v2 suite: 75 passed; arith suite (incl. `test_arith_hard`, which exercises real Z3 proofs): 89 passed.
- All 17 downstream reducer kernels compile and pass numerics — including three kernels whose layout inference genuinely depends on Z3 proofs (they fail if Z3 is disabled outright, confirming the lazy path preserves semantics where Z3 is load-bearing).
- Generated CUDA is byte-identical to the eager build under disabled ASLR. The only deltas observed with ASLR are AllReduce workspace slot permutations, which come from a pre-existing pointer-order nondeterminism in shared-memory planning (the same binary flips between runs; `setarch -R` makes both builds deterministic) — worth fixing separately.