### PR TITLE
[Fix] Give each materialized Z3 solver a private context

### DIFF
--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -639,14 +639,16 @@ class IntSetAnalyzer {
 /*!
  * \brief Enter a thread-local Z3 context scope.
  *
- * The outermost scope creates a fresh Z3 context. Nested scopes on the same
- * thread reuse that context so all Analyzers created during one compilation
- * can share it.
+ * Deprecated no-op. Every materialized Z3 solver owns a private context,
+ * which subsumes the per-compilation isolation these scopes provided; kept
+ * only until the remaining downstream call sites are removed.
  */
 TVM_DLL void EnterZ3ContextScope();
 
 /*!
  * \brief Exit the current thread-local Z3 context scope.
+ *
+ * Deprecated no-op, see EnterZ3ContextScope.
  */
 TVM_DLL void ExitZ3ContextScope();
 

--- a/src/target/z3/z3_prover_on.cc
+++ b/src/target/z3/z3_prover_on.cc
@@ -133,8 +133,10 @@ public:
 
   Analyzer* analyzer;
   /// @brief Z3 context, a shared ptr, because tilelang want to copy the Analyzer
-  // Analyzers created in one compile scope share a context. Keeping the pointer
-  // on each prover also lets cloned Analyzers safely outlive that scope.
+  // Before materialization this aliases the compile scope's context; when
+  // the solver materializes it is replaced by a context private to this
+  // prover (see Materialize), which clones of a materialized prover then
+  // share so their copied handles stay valid.
   std::shared_ptr<z3::context> ctx;
 
   /// @brief Z3 solver instance
@@ -228,6 +230,16 @@ public:
   /// for these entries, so CanProve answers are unchanged.
   void Materialize() {
     if (solver) return;
+    // The solver gets its own context: verdicts under the deterministic
+    // rlimit budget depend on the context's accumulated AST state (ids feed
+    // the search heuristics), so sharing a context couples every solver's
+    // borderline answers to whichever analyzers happened to be created
+    // before it. A private context makes each analyzer's answers a pure
+    // function of its own journal and query history. Unmaterialized clones
+    // still share the scope context captured at construction, which keeps
+    // Z3ContextScope's lifetime guarantees for exprs created before this
+    // point (there are none) trivially intact.
+    ctx = std::make_shared<z3::context>();
     solver.emplace(CreateSolver(*ctx));
     if (timeout_ms != UINT_MAX) {
       solver->set("timeout", timeout_ms);
@@ -408,6 +420,12 @@ public:
 
   /// @brief Binded
   /// @brief Bind a variable to a value or a range
+  /// A bind journaled inside a live constraint scope is dropped with that
+  /// scope. The eager path differed only cosmetically: it kept the var's
+  /// memo translation after the scope's solver frame (and with it the
+  /// var's range asserts) was popped, leaving an unconstrained placeholder
+  /// -- observably the same as translating the var as a fresh free
+  /// variable on demand, which is what a later query on the journal does.
   void Bind(const Var & var, const PrimExpr & value, bool allow_override = false) {
     if (!IsValidDType(var->dtype)) return;
     scope_stack_.back().push_back(Scope{

--- a/src/target/z3/z3_prover_on.cc
+++ b/src/target/z3/z3_prover_on.cc
@@ -83,48 +83,17 @@ struct Namespace {
   }
 };
 
-struct Z3ContextState {
-  std::shared_ptr<z3::context> fallback_context;
-  std::shared_ptr<z3::context> scoped_context;
-  size_t scope_depth{0};
-};
-
-Z3ContextState& GetZ3ContextState() {
-  static thread_local Z3ContextState state;
-  return state;
-}
-
-std::shared_ptr<z3::context> GetCurrentZ3Context() {
-  auto& state = GetZ3ContextState();
-  if (state.scope_depth != 0) {
-    TVM_FFI_ICHECK(state.scoped_context != nullptr);
-    return state.scoped_context;
-  }
-  if (state.fallback_context == nullptr) {
-    state.fallback_context = std::make_shared<z3::context>();
-  }
-  return state.fallback_context;
-}
-
 }  // namespace
 
-void EnterZ3ContextScope() {
-  auto& state = GetZ3ContextState();
-  if (state.scope_depth == 0) {
-    state.scoped_context = std::make_shared<z3::context>();
-  }
-  ++state.scope_depth;
-}
+// Deprecated no-ops, kept only for downstream callers of
+// arith.EnterZ3ContextScope / arith.ExitZ3ContextScope (Z3ContextScope in
+// Python). Shared per-compile z3 contexts are gone: every materialized
+// solver owns a private context (see Z3Prover::Impl::Materialize), which
+// subsumes the per-compile isolation these scopes provided. Remove together
+// with the remaining call sites.
+void EnterZ3ContextScope() {}
 
-void ExitZ3ContextScope() {
-  auto& state = GetZ3ContextState();
-  TVM_FFI_ICHECK_GT(state.scope_depth, 0U)
-      << "ExitZ3ContextScope called without a matching EnterZ3ContextScope";
-  --state.scope_depth;
-  if (state.scope_depth == 0) {
-    state.scoped_context.reset();
-  }
-}
+void ExitZ3ContextScope() {}
 
 class Z3Prover::Impl : ExprFunctor<z3::expr(const PrimExpr &)> {
 public:
@@ -132,11 +101,10 @@ public:
   using Self = Z3Prover::Impl;
 
   Analyzer* analyzer;
-  /// @brief Z3 context, a shared ptr, because tilelang want to copy the Analyzer
-  // Before materialization this aliases the compile scope's context; when
-  // the solver materializes it is replaced by a context private to this
-  // prover (see Materialize), which clones of a materialized prover then
-  // share so their copied handles stay valid.
+  /// @brief Z3 context owning every handle of this prover.
+  // Null until the solver materializes; Materialize creates a context
+  // private to this prover, which clones of a materialized prover then
+  // share (shared_ptr) so their copied handles stay valid.
   std::shared_ptr<z3::context> ctx;
 
   /// @brief Z3 solver instance
@@ -201,14 +169,14 @@ public:
   }
 
   Impl(Analyzer* parent)
-      : analyzer(parent), ctx(GetCurrentZ3Context()) {
-    // The solver is created lazily (see Materialize). Analyzers are
-    // constructed in large numbers as cheap scratch objects, and only a tiny
-    // fraction ever reaches the Z3 fallback of CanProve; creating the solver
-    // (and translating every Bind into z3 constraints) eagerly made every
-    // Analyzer pay Z3's initialization cost up front. Until the first
-    // operation that actually needs the solver, Bind/EnterConstraint only
-    // journal their arguments into scope_stack_.
+      : analyzer(parent) {
+    // The solver (and its context) is created lazily (see Materialize).
+    // Analyzers are constructed in large numbers as cheap scratch objects,
+    // and only a tiny fraction ever reaches the Z3 fallback of CanProve;
+    // creating the solver (and translating every Bind into z3 constraints)
+    // eagerly made every Analyzer pay Z3's initialization cost up front.
+    // Until the first operation that actually needs the solver,
+    // Bind/EnterConstraint only journal their arguments into scope_stack_.
     scope_stack_.push_back({});
     scope_side_effects_.push_back({});
     // default timeout 5ms
@@ -235,10 +203,8 @@ public:
     // the search heuristics), so sharing a context couples every solver's
     // borderline answers to whichever analyzers happened to be created
     // before it. A private context makes each analyzer's answers a pure
-    // function of its own journal and query history. Unmaterialized clones
-    // still share the scope context captured at construction, which keeps
-    // Z3ContextScope's lifetime guarantees for exprs created before this
-    // point (there are none) trivially intact.
+    // function of its own journal and query history. Unmaterialized provers
+    // hold no context (and no z3 state) at all.
     ctx = std::make_shared<z3::context>();
     solver.emplace(CreateSolver(*ctx));
     if (timeout_ms != UINT_MAX) {


### PR DESCRIPTION
Follow-up to #68 (this commit was pushed to the PR branch after the merge, so it did not land).

## Symptom

With #68 as merged, two tilelang tests fail — the grouped-compile / z3-context isolation tests (`test_tilelang_layout_inference_z3_context.py`) — with `no available layout found`: an injectivity proof over strided dynamic layouts that used to succeed now fails.

## Root cause

CanProve verdicts near the deterministic rlimit budget depend on the z3 context's accumulated AST state (ast ids feed the search heuristics), and all analyzers in a compile scope share one context. Eagerly, that shared state was the accumulation of every analyzer ever constructed — huge, but the same on every run. Lazily, only the few analyzers that materialize contribute, so the shared state shrank by orders of magnitude and proofs sitting right at the budget flipped their verdict. Query-log A/B against the eager build shows the first 449 Z3 queries answer identically; the divergence is a single conjunction query at the rlimit boundary, not a missing constraint.

## Fix

Each materialized solver gets a private `z3::context`. Every analyzer's verdicts become a pure function of its own journal and query history, independent of what else the compile happens to instantiate — the same isolation direction as #62, taken to per-solver granularity. Clones of a materialized prover adopt the source's context so copied handles stay valid; unmaterialized provers own no z3 state at all.

Also documents why binds journaled inside constraint scopes need no special replay handling: the eager path kept only an unconstrained memo placeholder after the scope's frame was popped, observably the same as translating the variable as a fresh free variable on demand.

## Cost & validation

- Private-context creation is paid only by materialized solvers (~200 per kernel, ~0.3% of analyzers): toy-kernel lower goes 0.132s → 0.164s, still well below the eager 0.21–0.23s; multi-second kernels are unaffected (attention suite unchanged at ~2x faster than eager overall).
- Cold-cache validation: layout suite 298 passed (including both previously failing tests), language suite 1172 passed / 137 skipped, arith 89 passed, reducer_v2 75 passed, 17 downstream reducer kernels compile and pass numerics.