### PR TITLE
[BugFix][TIRx] Legalize BF16 conversions inside Let and Bind values

### DIFF
--- a/src/tirx/transform/unsupported_dtype_legalize.cc
+++ b/src/tirx/transform/unsupported_dtype_legalize.cc
@@ -268,7 +268,7 @@ class ComputeLegalizer : public StmtExprMutator {
   }
 
   PrimExpr VisitExpr_(const LetNode* op) final {
-    PrimExpr value = PromoteToTarget(op->value);
+    PrimExpr value = PromoteToTarget(this->VisitExpr(op->value));
     Var var = op->var;
     if (value.dtype() != op->value.dtype()) {
       var = op->var.copy_with_dtype(op->value.dtype());
@@ -298,7 +298,7 @@ class ComputeLegalizer : public StmtExprMutator {
   DEFINE_BIOP_EXPR_LEGALIZE(NENode, operator!=);
 
   Stmt VisitStmt_(const BindNode* op) final {
-    PrimExpr value = PromoteToTarget(op->value);
+    PrimExpr value = PromoteToTarget(this->VisitExpr(op->value));
     Var var = op->var;
     if (value.dtype() != op->value.dtype()) {
       var = op->var.copy_with_dtype(op->value.dtype());

--- a/tests/python/tirx-transform/test_tir_transform_bf16_legalize.py
+++ b/tests/python/tirx-transform/test_tir_transform_bf16_legalize.py
@@ -448,6 +448,74 @@ def test_bf16_reduce_wont_legalize():
     tvm.ir.assert_structural_equal(after_storage, BindTarget(target)(after_storage_legalize()))
 
 
+def test_bf16_bind_value_will_legalize():
+    """A conversion inside a bound value is legalized like any other."""
+
+    def get_before():
+        @tvm.script.ir_module
+        class Before:
+            @T.prim_func
+            def main(Aptr: T.handle("bfloat16"), Cptr: T.handle("float32")):
+                T.func_attr({"global_symbol": "main"})
+                A = T.decl_buffer((100,), "bfloat16", data=Aptr)
+                C = T.decl_buffer((100,), "float32", data=Cptr)
+                for i in T.grid(100):
+                    b: T.float32 = T.Cast("float32", A[i])
+                    C[i] = b * T.float32(2)
+
+        return Before
+
+    def after_compute_legalize():
+        @tvm.script.ir_module
+        class After:
+            @T.prim_func
+            def main(Aptr: T.handle("bfloat16"), Cptr: T.handle("float32")):
+                T.func_attr({"global_symbol": "main"})
+                A = T.decl_buffer((100,), "bfloat16", data=Aptr)
+                C = T.decl_buffer((100,), "float32", data=Cptr)
+                for i in T.grid(100):
+                    b: T.float32 = bf16tof32(A[i])
+                    C[i] = b * T.float32(2)
+
+        return After
+
+    target = Target("nvidia/geforce-rtx-2080-ti")
+    before = BindTarget(target)(get_before())
+    after_compute = tvm.tirx.transform.BF16ComputeLegalize()(before)
+    tvm.ir.assert_structural_equal(after_compute, BindTarget(target)(after_compute_legalize()))
+
+
+def test_bf16_let_value_will_legalize():
+    """A conversion inside a Let expression's value is legalized like any other."""
+    A = tvm.tirx.decl_buffer((100,), "bfloat16", name="A")
+    C = tvm.tirx.decl_buffer((100,), "float32", name="C")
+    i = tvm.tirx.Var("i", "int32")
+    x = tvm.tirx.Var("x", "float32")
+    value = tvm.tirx.Cast("float32", tvm.tirx.BufferLoad(A, [i]))
+    store = tvm.tirx.BufferStore(C, tvm.tirx.Let(x, value, x * tvm.tirx.const(2.0, "float32")), [i])
+    loop = tvm.tirx.For(i, 0, 100, tvm.tirx.ForKind.SERIAL, store)
+    body = tvm.tirx.SeqStmt([tvm.tirx.DeclBuffer(A), tvm.tirx.DeclBuffer(C), loop])
+    func = tvm.tirx.PrimFunc([A.data, C.data], body).with_attr("global_symbol", "main")
+    target = Target("nvidia/geforce-rtx-2080-ti")
+    before = BindTarget(target)(tvm.IRModule({"main": func}))
+    after_compute = tvm.tirx.transform.BF16ComputeLegalize()(before)
+
+    lets, bf16_casts = [], []
+
+    def visit(node):
+        if isinstance(node, tvm.tirx.Let):
+            lets.append(node)
+        if isinstance(node, tvm.tirx.Cast) and "bfloat16" in (
+            str(node.dtype),
+            str(node.value.dtype),
+        ):
+            bf16_casts.append(node)
+
+    tvm.tirx.stmt_functor.post_order_visit(after_compute["main"].body, visit)
+    assert len(lets) == 1
+    assert bf16_casts == []
+
+
 if __name__ == "__main__":
     test_bf16_storage_compute_scope_will_legalize()
     test_bf16_storage_compute_scope_wont_legalize()


### PR DESCRIPTION
## Problem

`BF16ComputeLegalize` leaves a BF16 conversion in place when it sits inside the value of a `Let` expression or a `Bind` statement. `BF16StorageLegalize` then retypes the BF16 buffer to `uint16`, and the surviving `Cast("float32", A[i])` becomes an integer-to-float conversion of the raw bits. A kernel that writes

```python
b: T.float32 = T.Cast("float32", A[i])
C[i] = b * T.float32(2)
```

reads BF16 `1/1024` as `14976.0`. The same kernel with the cast written inline at the use site is legalized correctly.

## Root cause

`ComputeLegalizer::VisitExpr_(const LetNode*)` and `VisitStmt_(const BindNode*)` call `PromoteToTarget(op->value)` on the unvisited value. Every other handler in the class (`Cast`, `Select`, `Broadcast`, `Shuffle`, `BufferStore`, the binary operators) calls `PromoteToTarget(this->VisitExpr(...))`. Nothing in TileLang runs this pass on the CPU pipeline today, and the CUDA gate skips it, so the two handlers had not processed real IR.

## Change

- `src/tirx/transform/unsupported_dtype_legalize.cc`: visit the bound value before promoting it, in both handlers.

## Tests

`tests/python/tirx-transform/test_tir_transform_bf16_legalize.py`:

- `test_bf16_bind_value_will_legalize`: a typed assignment in script (a `Bind`) whose value casts a BF16 load; structural equality against the legalized form.
- `test_bf16_let_value_will_legalize`: a `Let` expression built directly; asserts the `Let` survives and no cast to or from `bfloat16` remains.

## Validation

Apple M-series, macOS 15, built inside TileLang (`85fd8fc2`) with `USE_METAL=ON USE_LLVM=ON` (LLVM 20.1.8).

```
pytest tests/python/tirx-transform/test_tir_transform_bf16_legalize.py    7 passed
```

With TileLang's CPU pipeline running `BF16ComputeLegalize` (companion TileLang PR), `testing/python/cpu` plus `testing/python/llvm`: 120 passed, 0 failed. A downstream BF16 pointwise kernel that binds its casts computes correctly on the LLVM target with this change and reads raw bits without it.

## Related

- TileLang PR `[BugFix][CPU] Legalize BF16 arithmetic in the CPU pipeline` adds `BF16ComputeLegalize` to `CPUPassPipelineBody`. It is independent of this fix and can merge in either order: it repairs the compile failures on its own, and this fix repairs the remaining case of a conversion bound to a variable, which TileLang's eager frontend emits for every assignment.
- Follow-up in TileLang once this merges: bump `3rdparty/tvm`, and extend `testing/python/cpu/test_tilelang_cpu_bf16_legalize.py` with the bound-value kernel (`a, b = A[i].astype("float32"), B[i].astype("float32")`) in both the device-free lowering check and the LLVM execution check. Those cases fail against the current `3rdparty/tvm` and pass with this change; they were left out of the TileLang PR for that reason.
